### PR TITLE
Always return node in connect method

### DIFF
--- a/src/AudioNodes/Effects/Input.js
+++ b/src/AudioNodes/Effects/Input.js
@@ -72,7 +72,7 @@ export default class Input extends SingleAudioNode {
         if (typeof this._node === 'undefined') {
             this._deferredConnects.push(node);
 
-            return;
+            return node;
         }
 
         // Check if the node is a Audio-effects AudioNode,


### PR DESCRIPTION
It's me again :)

Testing a simple example like this:

``` js
import {Input, Output, Distortion} from 'audio-effects'

const audioContext = new AudioContext()
const input = new Input(audioContext)
input.getUserMedia()
const output = new Output(audioContext)

const distortion = new Distortion(audioContext)
distortion.intensity = 2000; // Set the intensity to 200
distortion.gain = 100; // Set the gain to 100

input.connect(distortion).connect(output)
```

Gives me a `Uncaught TypeError: Cannot read property 'connect' of undefined` because `connect` in `Input` [returns undefined](https://github.com/Sambego/audio-effects/blob/master/src/AudioNodes/Effects/Input.js#L75). I'm not sure this PR is valid but returning the node removes this error.
